### PR TITLE
[LA.UM.7.1.r1] cp_headers: Add VIDC 3X media/msm_vidc.h header.

### DIFF
--- a/cp_headers.sh
+++ b/cp_headers.sh
@@ -65,6 +65,7 @@ UAPI_HEADERS="\
     media/msmb_pproc.h\
     media/msm_media_info.h\
     media/msm_sde_rotator.h\
+    media/msm_vidc.h\
     media/msm_vidc_utils.h\
     video/msm_hdmi_modes.h\
     scsi/ufs/ufs.h\


### PR DESCRIPTION
Depends on https://github.com/sonyxperiadev/kernel/pull/2173

This header is used by the "legacy" sdm660 media HAL and provided by the
ported VIDC 3X driver.