### PR TITLE
[DONOTMERGE] [common-headers] [4.19] Export headers in blueprint package as qti_kernel_headers

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -1,0 +1,5 @@
+cc_library_headers {
+    name: "qti_kernel_headers",
+    vendor: true,
+    export_include_dirs: ["kernel-headers"],
+}


### PR DESCRIPTION
`dataservices` requires the `linux/rmnet_data.h` header, which is somehow not made available through `PRODUCT_VENDOR_KERNEL_HEADERS`. Note that this CAF library appears to be one of the first to use BluePrint, and "conveniently" already depends on an inexistant `qti_kernel_headers` that we would otherwise have to remove.

@ix5 Can you confirm? Am I doing something stupid and should `PRODUCT_VENDOR_KERNEL_HEADERS` be available to all packages, including those built 'through' BP?