### PR TITLE
[9.12.r1] [1/3] Android.bp: Define soong namespace

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -1,3 +1,5 @@
+soong_namespace {}
+
 cc_library_headers {
     name: "qti_kernel_headers",
     vendor_available: true,


### PR DESCRIPTION
This is necessary for two kernel-headers repos to co-exist under kernel/sony/msm-X.Y/kernel-headers