### PR TITLE
[headers] [7.1] cp_headers: Include drm header

### DIFF
--- a/cp_headers.sh
+++ b/cp_headers.sh
@@ -71,8 +71,10 @@ UAPI_HEADERS="\
     video/msm_hdmi_modes.h\
     scsi/ufs/ufs.h\
     scsi/ufs/ioctl.h\
-    drm/msm_drm.h\
+    drm/drm.h\
     drm/drm_fourcc.h\
+    drm/drm_mode.h\
+    drm/msm_drm.h\
     drm/msm_drm_pp.h\
     drm/sde_drm.h\
     asm-generic/ioctls.h"


### PR DESCRIPTION
On the new media HAL the `drm_fourcc.h` header is actually used, transitively including drm.h:

    In file included from vendor/qcom/opensource/display/gralloc/gr_utils.cpp:34:
    kernel/sony/msm-4.14/common-headers/kernel-headers/drm/drm_fourcc.h:21:10: fatal error: 'drm.h' file not found
    #include "drm.h"
             ^~~~~~~

# TODO:

Actually run the generation script! It's horribly still python 2 and throws all kinds of conflicts with the `clang_android.so` library that I don't have the time to look into now...
