### PR TITLE
[9.12] Android.bp: Append 4.19 to module name

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -1,5 +1,5 @@
 cc_library_headers {
-    name: "qti_kernel_headers",
+    name: "qti_kernel_headers_4.19",
     vendor_available: true,
     export_include_dirs: ["kernel-headers"],
 }


### PR DESCRIPTION
The resulting module is named `qti_kernel_headers_4.19`.

This change, combined with a tool that resolves `qti_kernel_headers` to the correct module depending on platform kernel version (i.e. `SOMC_KERNEL_VERSION`), will allow multiple kernel versions to live side-by-side in one AOSP tree.